### PR TITLE
商品詳細ページ　購入・編集・ログインボタン　配置

### DIFF
--- a/app/assets/stylesheets/modules/_items.scss
+++ b/app/assets/stylesheets/modules/_items.scss
@@ -96,7 +96,7 @@ body{
 
 // ------- フッター ------------
   footer {
-    height: 100vh;
+    height: 750px;
     width: 100vw;
     background-color: #272727;
     padding: 0px 60px;

--- a/app/assets/stylesheets/modules/_items_show.scss
+++ b/app/assets/stylesheets/modules/_items_show.scss
@@ -125,7 +125,6 @@ a {
           height: 100px;
           width: 400px;
         }
-        
       }
 
       .Option-area {

--- a/app/assets/stylesheets/modules/_items_show.scss
+++ b/app/assets/stylesheets/modules/_items_show.scss
@@ -107,11 +107,18 @@ a {
         justify-content: center;
         .Items-btn {
           margin-top: 30px;
+          text-align: center;
+          display: flex;
+          align-items: center;
+          justify-content: center;
           a {
             display: block;
             height: 100px;
             width: 400px;
             border: 1px solid #000;
+            display: flex;
+            align-items: center;
+            justify-content: center;
           }
         }
         .seller-btn {

--- a/app/assets/stylesheets/modules/_items_show.scss
+++ b/app/assets/stylesheets/modules/_items_show.scss
@@ -9,7 +9,7 @@ a {
 
 .Wrapper {
   width: 100vw;
-  height: 2100px;
+  height: 2250px;
   background-color: #f5ffee;
 
   .List-box {
@@ -48,7 +48,7 @@ a {
     flex-direction: column;
     .Items {
       padding: 40px;
-      height: 1600px;
+      height: 1750px;
       width: 700px;
       background-color: #fff;
       display: flex;
@@ -80,7 +80,7 @@ a {
         margin: 20px 0px;
         text-align: justify;
       }
-
+      
       .Menu {
         &__list {
           border: 1px solid #797979;
@@ -98,9 +98,25 @@ a {
           }
         }
       }
+      
+      // 購入、変更、ログインボタン
+      .Btn-area {
+        height: 150px;
+        width: 700px;
+        display: flex;
+        justify-content: center;
+        .Items-btn {
+          height: 100px;
+          width: 400px;
+          border: 1px solid #000;
+          margin-top: 30px;
+        }
+
+        
+      }
 
       .Option-area {
-        margin: 10px;
+        margin-top: 20px;
         width: 500px;
         display: flex;
         justify-content: space-between;

--- a/app/assets/stylesheets/modules/_items_show.scss
+++ b/app/assets/stylesheets/modules/_items_show.scss
@@ -106,12 +106,18 @@ a {
         display: flex;
         justify-content: center;
         .Items-btn {
+          margin-top: 30px;
+          a {
+            display: block;
+            height: 100px;
+            width: 400px;
+            border: 1px solid #000;
+          }
+        }
+        .seller-btn {
           height: 100px;
           width: 400px;
-          border: 1px solid #000;
-          margin-top: 30px;
         }
-
         
       }
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -24,6 +24,7 @@ class ItemsController < ApplicationController
   end
 
   def show
+    @item = Item.find(params[:id])
   end
 
   def update

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -91,6 +91,21 @@
             %td.Menu__list__right
               4-7日で発送
 
+        .Btn-area
+          - if user_signed_in? && current_user.id == @item.seller_id
+            .Items-btn.seller-btn
+              編集・削除はこちらから
+          - elsif user_signed_in? && current_user.id != @item.seller_id
+            .Items-btn.buyer-btn
+              購入する
+          - else
+            .Items-btn.login-btn
+              %span.login-btn__up
+                ※ログインすると購入できます。
+                %br
+              %span.login-btn__down
+                ログインはこちらから
+
         .Option-area
           .Favorite
             ★ お気に入り ０

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -105,10 +105,8 @@
           - else
             .Items-btn.login-btn
               = link_to "#" do
-                %span.login-btn__up
                   ※ログインすると購入できます。
                   %br
-                %span.login-btn__down
                   ログインはこちらから
 
         .Option-area

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -94,17 +94,22 @@
         .Btn-area
           - if user_signed_in? && current_user.id == @item.seller_id
             .Items-btn.seller-btn
-              編集・削除はこちらから
+              = link_to "#" do
+                編集・削除はこちらから
+
           - elsif user_signed_in? && current_user.id != @item.seller_id
             .Items-btn.buyer-btn
-              購入する
+              = link_to "#" do
+                購入する
+
           - else
             .Items-btn.login-btn
-              %span.login-btn__up
-                ※ログインすると購入できます。
-                %br
-              %span.login-btn__down
-                ログインはこちらから
+              = link_to "#" do
+                %span.login-btn__up
+                  ※ログインすると購入できます。
+                  %br
+                %span.login-btn__down
+                  ログインはこちらから
 
         .Option-area
           .Favorite

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -105,6 +105,7 @@
           - else
             .Items-btn.login-btn
               = link_to "#" do
+                %span
                   ※ログインすると購入できます。
                   %br
                   ログインはこちらから


### PR DESCRIPTION
#What
商品詳細ページにおける　購入・編集・ログインボタンのレイアウト決め。

#Why
編集ページ、購入ページなどで使用するボタンに使う為。
以下のように切り替わる。

売り手ログイン時　→　編集ボタン
買い手ログイン時　→　購入ボタン
未ログイン時　　　→　ログイン誘導ボタン

<img width="901" alt="スクリーンショット 2020-07-13 18 06 08" src="https://user-images.githubusercontent.com/66356762/87286588-fef9a900-c533-11ea-876f-9bcb50dd13c2.png">
<img width="1000" alt="727aba34ca7c5e77ea586aa19d3011d8" src="https://user-images.githubusercontent.com/66356762/87286600-015c0300-c534-11ea-91ba-ea45cd8e16f7.png">
<img width="782" alt="スクリーンショット 2020-07-13 18 05 34" src="https://user-images.githubusercontent.com/66356762/87286607-028d3000-c534-11ea-81d5-5764c0a64c8d.png">

