### PR TITLE
商品詳細ページの修正

### DIFF
--- a/app/assets/stylesheets/modules/_items_show.scss
+++ b/app/assets/stylesheets/modules/_items_show.scss
@@ -96,6 +96,12 @@ a {
             color: #fff;
           }
         }
+        // 購入済みメッセージ
+        .item-purchase {
+          margin-top: 55px;
+          font-size: 25px;
+          color: #e43333;
+        }
 
         // 編集ボタン
         .seller-btn {

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -68,6 +68,10 @@
             .Items-btn.seller-btn
               = link_to edit_item_path(@item.id) do
                 編集・削除はこちらから
+          
+          - elsif @item.buyer_id.present?
+            .item-purchase
+              ※この商品は既に購入されております
 
           - elsif user_signed_in? && current_user.id != @item.seller_id
             .Items-btn.buyer-btn


### PR DESCRIPTION
# What
商品が購入済みの場合にも「購入ボタン」が表示されないようにする。

# Why
購入済みにもかかわらず、「購入ボタン」が表示されているのは適切ではない為。

![ボタンの削除](https://user-images.githubusercontent.com/66356762/88128517-19f1aa80-cc11-11ea-8528-565e033f8e11.gif)